### PR TITLE
pf: allow to optionally specify multiple NAT interfaces

### DIFF
--- a/bsdploy/roles/jails_host/defaults/main.yml
+++ b/bsdploy/roles/jails_host/defaults/main.yml
@@ -14,6 +14,8 @@ pf_nat_jail_networks:
     - 10.0.0.0/8
 pf_nat_rules: []
 pf_nat_interface: "{{ansible_default_ipv4.interface}}"
+pf_nat_interfaces:
+    - "{{pf_nat_interface}}"
 ploy_jail_host_sshd_listenaddress: "{{ ansible_default_ipv4.address }}"
 ploy_jail_host_pkg_repository_kind: "quarterly"
 ploy_jail_host_pkg_repository_url: "pkg+http://pkg.freeBSD.org/${ABI}/{{ ploy_jail_host_pkg_repository_kind }}"

--- a/bsdploy/roles/jails_host/templates/pf.conf
+++ b/bsdploy/roles/jails_host/templates/pf.conf
@@ -1,5 +1,7 @@
 {% for network in pf_nat_jail_networks %}
-nat on {{ pf_nat_interface }} from {{ network }} to any -> ({{ pf_nat_interface }})
+{% for nat_interface in pf_nat_interfaces %}
+nat on {{ nat_interface }} from {{ network }} to any -> ({{ nat_interface }})
+{% endfor %}
 {% endfor %}
 {% for rule in pf_nat_rules %}
 {{ rule }}


### PR DESCRIPTION
the typical use-case for this is when you have a VirtualBox
instance with two interfaces - one host-only interface and one NATted
interface.

if only one of these interfaces are NATted you either won't be able
to access jails on the host via the host-only interface or the jails
won't be able to communicate with the internet.

only configuring both interfaces for NAT via `pf` allows for both
to take place.

to set more than one interface, simply define `pf_nat_interfaces`
in a playbook.

to set only one interface (i.e. if you don't want the default) set
`pf_nat_interface` (note the singular) as usual.
